### PR TITLE
ProjectManager-0.9.0 *** NEW JAR ***

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -7,7 +7,7 @@
     <import file="nbproject/build-impl.xml"/>
     
     <!-- set the version of ProjectManager here -->
-    <property name="version" value="ProjectManager-0.8.8a"/>
+    <property name="version" value="ProjectManager-0.9.0"/>
     
     <!-- This creates the jar that we want with the included dependancies -->
     <!-- There should be no need to edit this code -->

--- a/src/com/elle/ProjectManager/logic/Tab.java
+++ b/src/com/elle/ProjectManager/logic/Tab.java
@@ -36,8 +36,15 @@ public class Tab implements ITableConstants{
     private boolean archiveRecordMenuItemEnabled;  // enables archive record menu item
     private boolean addRecordsBtnVisible;          // sets the add records button visible
     private boolean batchEditBtnVisible;           // sets the batch edit button visible
+    private boolean batchEditBtnEnabled;           // sets the batch edit button enabled
+    private boolean AddRecordsBtnEnabled;          // sets the Add Records button enabled
     
-
+    // each tab can either be editing or not
+    private boolean Editing;   
+    
+    // batch edit window states
+    private boolean batchEditWindowOpen;
+    private boolean batchEditWindowVisible;
     
     /**
      * CONSTRUCTOR
@@ -53,6 +60,9 @@ public class Tab implements ITableConstants{
         archiveRecordMenuItemEnabled = false;
         addRecordsBtnVisible = false;
         batchEditBtnVisible = false;
+        batchEditBtnEnabled = true;
+        batchEditWindowOpen = false;
+        batchEditWindowVisible = false;
     }
     
     /**
@@ -213,7 +223,47 @@ public class Tab implements ITableConstants{
         this.tableData = tableData;
     }
     
+    public boolean isEditing() {
+        return Editing;
+    }
 
+    public void setEditing(boolean Editing) {
+        this.Editing = Editing;
+    }
+
+    public boolean isBatchEditBtnEnabled() {
+        return batchEditBtnEnabled;
+    }
+
+    public void setBatchEditBtnEnabled(boolean batchEditBtnEnabled) {
+        this.batchEditBtnEnabled = batchEditBtnEnabled;
+    }
+
+    public boolean isBatchEditWindowOpen() {
+        return batchEditWindowOpen;
+    }
+
+    public void setBatchEditWindowOpen(boolean batchEditWindowOpen) {
+        this.batchEditWindowOpen = batchEditWindowOpen;
+    }
+
+    public boolean isBatchEditWindowVisible() {
+        return batchEditWindowVisible;
+    }
+
+    public void setBatchEditWindowVisible(boolean batchEditWindowVisible) {
+        this.batchEditWindowVisible = batchEditWindowVisible;
+    }
+
+    public boolean isAddRecordsBtnEnabled() {
+        return AddRecordsBtnEnabled;
+    }
+
+    public void setAddRecordsBtnEnabled(boolean AddRecordsBtnEnabled) {
+        this.AddRecordsBtnEnabled = AddRecordsBtnEnabled;
+    }
+    
+    
     /**************************************************************************
      *************************** Methods **************************************
      **************************************************************************/

--- a/src/com/elle/ProjectManager/presentation/BatchEditWindow.java
+++ b/src/com/elle/ProjectManager/presentation/BatchEditWindow.java
@@ -221,8 +221,16 @@ public class BatchEditWindow extends JFrame {
      */
     private void btnQuitActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_btnQuitActionPerformed
 
-        projectManagerWindow.getjPanelEdit().setVisible(true);
-        this.dispose();
+        // set the states for the editing tab
+        tab.setBatchEditWindowOpen(false);
+        tab.setBatchEditWindowVisible(false);
+        tab.setBatchEditBtnEnabled(true);
+        
+        // set the batch edit button enabled
+        projectManagerWindow.getBtnBatchEdit().setEnabled(true);
+        
+        // this instance should dispose
+        projectManagerWindow.getBatchEditWindow().dispose();
     }//GEN-LAST:event_btnQuitActionPerformed
 
     private void textFieldNewValueActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_textFieldNewValueActionPerformed

--- a/src/com/elle/ProjectManager/presentation/BatchEditWindow.java
+++ b/src/com/elle/ProjectManager/presentation/BatchEditWindow.java
@@ -1,8 +1,6 @@
 
 package com.elle.ProjectManager.presentation;
 
-import com.elle.ProjectManager.database.ModifiedData;
-import com.elle.ProjectManager.database.ModifiedTableData;
 import com.elle.ProjectManager.logic.Tab;
 import com.elle.ProjectManager.logic.TableFilter;
 import java.util.ArrayList;
@@ -222,7 +220,7 @@ public class BatchEditWindow extends JFrame {
      * @param evt 
      */
     private void btnQuitActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_btnQuitActionPerformed
-        projectManagerWindow.getPanelBatchEditButtons().setVisible(false);
+
         projectManagerWindow.getjPanelEdit().setVisible(true);
         this.dispose();
     }//GEN-LAST:event_btnQuitActionPerformed

--- a/src/com/elle/ProjectManager/presentation/LoginWindow.java
+++ b/src/com/elle/ProjectManager/presentation/LoginWindow.java
@@ -44,9 +44,7 @@ public class LoginWindow extends JFrame {
 //        comboBoxDatabase.setSelectedIndex(3);
         
         // show window
-        this.setTitle("Log in");
-        this.setVisible(false);
-        
+        this.setTitle("Log in");  
     }
 
     /**

--- a/src/com/elle/ProjectManager/presentation/ProjectManagerWindow.form
+++ b/src/com/elle/ProjectManager/presentation/ProjectManagerWindow.form
@@ -246,7 +246,6 @@
         <DimensionLayout dim="0">
           <Group type="103" groupAlignment="0" attributes="0">
               <Component id="jPanelEdit" alignment="0" pref="823" max="32767" attributes="0"/>
-              <Component id="panelBatchEditButtons" alignment="0" pref="823" max="32767" attributes="0"/>
               <Group type="102" alignment="1" attributes="0">
                   <EmptySpace max="-2" attributes="0"/>
                   <Component id="jPanelSQL" max="32767" attributes="0"/>
@@ -261,9 +260,7 @@
                   <Component id="tabbedPanel" min="-2" pref="349" max="-2" attributes="0"/>
                   <EmptySpace max="-2" attributes="0"/>
                   <Component id="jPanelEdit" min="-2" pref="37" max="-2" attributes="0"/>
-                  <EmptySpace max="-2" attributes="0"/>
-                  <Component id="panelBatchEditButtons" min="-2" pref="33" max="-2" attributes="0"/>
-                  <EmptySpace max="-2" attributes="0"/>
+                  <EmptySpace min="-2" pref="12" max="-2" attributes="0"/>
                   <Component id="jPanelSQL" max="32767" attributes="0"/>
                   <EmptySpace min="0" pref="0" max="-2" attributes="0"/>
               </Group>
@@ -557,10 +554,10 @@
                       <Component id="jLabelEdit" min="-2" max="-2" attributes="0"/>
                       <EmptySpace type="unrelated" max="-2" attributes="0"/>
                       <Component id="btnSwitchEditMode" min="-2" max="-2" attributes="0"/>
-                      <EmptySpace max="-2" attributes="0"/>
-                      <Component id="btnCancelEditMode" min="-2" max="-2" attributes="0"/>
-                      <EmptySpace max="-2" attributes="0"/>
+                      <EmptySpace min="-2" pref="82" max="-2" attributes="0"/>
                       <Component id="btnUploadChanges" min="-2" max="-2" attributes="0"/>
+                      <EmptySpace max="-2" attributes="0"/>
+                      <Component id="btnRevertChangesBatchEdit1" min="-2" max="-2" attributes="0"/>
                       <EmptySpace max="32767" attributes="0"/>
                       <Component id="btnAddRecords" min="-2" max="-2" attributes="0"/>
                       <EmptySpace max="-2" attributes="0"/>
@@ -578,9 +575,9 @@
                           <Component id="jLabel2" alignment="3" min="-2" max="-2" attributes="0"/>
                           <Component id="btnSwitchEditMode" alignment="3" min="-2" max="-2" attributes="0"/>
                           <Component id="jLabelEdit" alignment="3" min="-2" max="-2" attributes="0"/>
-                          <Component id="btnCancelEditMode" alignment="3" min="-2" max="-2" attributes="0"/>
                           <Component id="btnBatchEdit" alignment="3" min="-2" max="-2" attributes="0"/>
                           <Component id="btnAddRecords" alignment="3" min="-2" max="-2" attributes="0"/>
+                          <Component id="btnRevertChangesBatchEdit1" alignment="3" min="-2" max="-2" attributes="0"/>
                       </Group>
                       <EmptySpace min="-2" pref="4" max="-2" attributes="0"/>
                   </Group>
@@ -618,14 +615,6 @@
                 <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="btnUploadChangesActionPerformed"/>
               </Events>
             </Component>
-            <Component class="javax.swing.JButton" name="btnCancelEditMode">
-              <Properties>
-                <Property name="text" type="java.lang.String" value="Cancel"/>
-              </Properties>
-              <Events>
-                <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="btnCancelEditModeActionPerformed"/>
-              </Events>
-            </Component>
             <Component class="javax.swing.JButton" name="btnSwitchEditMode">
               <Properties>
                 <Property name="text" type="java.lang.String" value="Switch"/>
@@ -643,6 +632,14 @@
               <Properties>
                 <Property name="text" type="java.lang.String" value="Edit Mode:"/>
               </Properties>
+            </Component>
+            <Component class="javax.swing.JButton" name="btnRevertChangesBatchEdit1">
+              <Properties>
+                <Property name="text" type="java.lang.String" value="Revert Changes"/>
+              </Properties>
+              <Events>
+                <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="btnRevertChangesBatchEdit1ActionPerformed"/>
+              </Events>
             </Component>
           </SubComponents>
         </Container>
@@ -742,62 +739,6 @@
             </Component>
           </SubComponents>
         </Container>
-        <Container class="javax.swing.JPanel" name="panelBatchEditButtons">
-          <Properties>
-            <Property name="preferredSize" type="java.awt.Dimension" editor="org.netbeans.beaninfo.editors.DimensionEditor">
-              <Dimension value="[636, 180]"/>
-            </Property>
-          </Properties>
-
-          <Layout>
-            <DimensionLayout dim="0">
-              <Group type="103" groupAlignment="0" attributes="0">
-                  <Group type="102" alignment="0" attributes="0">
-                      <EmptySpace max="32767" attributes="0"/>
-                      <Component id="btnUploadChangesBatchEdit" min="-2" max="-2" attributes="0"/>
-                      <EmptySpace min="-2" pref="18" max="-2" attributes="0"/>
-                      <Component id="btnRevertChangesBatchEdit" min="-2" max="-2" attributes="0"/>
-                      <EmptySpace max="32767" attributes="0"/>
-                  </Group>
-              </Group>
-            </DimensionLayout>
-            <DimensionLayout dim="1">
-              <Group type="103" groupAlignment="0" attributes="0">
-                  <Group type="102" alignment="0" attributes="0">
-                      <EmptySpace max="32767" attributes="0"/>
-                      <Group type="103" groupAlignment="3" attributes="0">
-                          <Component id="btnUploadChangesBatchEdit" alignment="3" min="-2" max="-2" attributes="0"/>
-                          <Component id="btnRevertChangesBatchEdit" alignment="3" min="-2" max="-2" attributes="0"/>
-                      </Group>
-                  </Group>
-              </Group>
-            </DimensionLayout>
-          </Layout>
-          <SubComponents>
-            <Component class="javax.swing.JButton" name="btnRevertChangesBatchEdit">
-              <Properties>
-                <Property name="text" type="java.lang.String" value="Revert Changes"/>
-              </Properties>
-              <Events>
-                <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="btnRevertChangesBatchEditActionPerformed"/>
-              </Events>
-            </Component>
-            <Component class="javax.swing.JButton" name="btnUploadChangesBatchEdit">
-              <Properties>
-                <Property name="text" type="java.lang.String" value="Upload Changes"/>
-                <Property name="maximumSize" type="java.awt.Dimension" editor="org.netbeans.beaninfo.editors.DimensionEditor">
-                  <Dimension value="[95, 30]"/>
-                </Property>
-                <Property name="minimumSize" type="java.awt.Dimension" editor="org.netbeans.beaninfo.editors.DimensionEditor">
-                  <Dimension value="[95, 30]"/>
-                </Property>
-              </Properties>
-              <Events>
-                <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="btnUploadChangesBatchEditActionPerformed"/>
-              </Events>
-            </Component>
-          </SubComponents>
-        </Container>
       </SubComponents>
     </Container>
     <Container class="javax.swing.JPanel" name="addPanel_control">
@@ -815,14 +756,14 @@
                   <Component id="searchPanel" min="-2" max="-2" attributes="0"/>
                   <EmptySpace max="-2" attributes="0"/>
                   <Component id="jPanel1" min="-2" max="-2" attributes="0"/>
-                  <EmptySpace pref="122" max="32767" attributes="0"/>
+                  <EmptySpace pref="123" max="32767" attributes="0"/>
               </Group>
           </Group>
         </DimensionLayout>
         <DimensionLayout dim="1">
           <Group type="103" groupAlignment="0" attributes="0">
               <Group type="102" alignment="0" attributes="0">
-                  <EmptySpace min="0" pref="9" max="32767" attributes="0"/>
+                  <EmptySpace min="0" pref="5" max="32767" attributes="0"/>
                   <Group type="103" groupAlignment="0" attributes="0">
                       <Component id="jPanel1" min="-2" max="-2" attributes="0"/>
                       <Component id="searchPanel" min="-2" max="-2" attributes="0"/>
@@ -893,7 +834,7 @@
                       <Component id="textFieldForSearch" min="-2" pref="141" max="-2" attributes="0"/>
                       <EmptySpace max="-2" attributes="0"/>
                       <Component id="btnSearch" min="-2" max="-2" attributes="0"/>
-                      <EmptySpace pref="92" max="32767" attributes="0"/>
+                      <EmptySpace pref="151" max="32767" attributes="0"/>
                   </Group>
               </Group>
             </DimensionLayout>
@@ -907,7 +848,7 @@
                           <Component id="textFieldForSearch" alignment="3" min="-2" max="-2" attributes="0"/>
                           <Component id="btnSearch" alignment="3" min="-2" max="-2" attributes="0"/>
                       </Group>
-                      <EmptySpace min="0" pref="33" max="32767" attributes="0"/>
+                      <EmptySpace min="0" pref="38" max="32767" attributes="0"/>
                   </Group>
               </Group>
             </DimensionLayout>

--- a/src/com/elle/ProjectManager/presentation/ProjectManagerWindow.form
+++ b/src/com/elle/ProjectManager/presentation/ProjectManagerWindow.form
@@ -557,7 +557,7 @@
                       <EmptySpace min="-2" pref="82" max="-2" attributes="0"/>
                       <Component id="btnUploadChanges" min="-2" max="-2" attributes="0"/>
                       <EmptySpace max="-2" attributes="0"/>
-                      <Component id="btnRevertChangesBatchEdit" min="-2" max="-2" attributes="0"/>
+                      <Component id="btnRevertChanges" min="-2" max="-2" attributes="0"/>
                       <EmptySpace max="32767" attributes="0"/>
                       <Component id="btnAddRecords" min="-2" max="-2" attributes="0"/>
                       <EmptySpace max="-2" attributes="0"/>
@@ -577,7 +577,7 @@
                           <Component id="labelEditModeState" alignment="3" min="-2" max="-2" attributes="0"/>
                           <Component id="btnBatchEdit" alignment="3" min="-2" max="-2" attributes="0"/>
                           <Component id="btnAddRecords" alignment="3" min="-2" max="-2" attributes="0"/>
-                          <Component id="btnRevertChangesBatchEdit" alignment="3" min="-2" max="-2" attributes="0"/>
+                          <Component id="btnRevertChanges" alignment="3" min="-2" max="-2" attributes="0"/>
                       </Group>
                       <EmptySpace min="-2" pref="4" max="-2" attributes="0"/>
                   </Group>
@@ -633,12 +633,12 @@
                 <Property name="text" type="java.lang.String" value="Edit Mode:"/>
               </Properties>
             </Component>
-            <Component class="javax.swing.JButton" name="btnRevertChangesBatchEdit">
+            <Component class="javax.swing.JButton" name="btnRevertChanges">
               <Properties>
                 <Property name="text" type="java.lang.String" value="Revert Changes"/>
               </Properties>
               <Events>
-                <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="btnRevertChangesBatchEditActionPerformed"/>
+                <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="btnRevertChangesActionPerformed"/>
               </Events>
             </Component>
           </SubComponents>

--- a/src/com/elle/ProjectManager/presentation/ProjectManagerWindow.form
+++ b/src/com/elle/ProjectManager/presentation/ProjectManagerWindow.form
@@ -549,15 +549,15 @@
               <Group type="103" groupAlignment="0" attributes="0">
                   <Group type="102" alignment="0" attributes="0">
                       <EmptySpace max="-2" attributes="0"/>
-                      <Component id="jLabel2" min="-2" max="-2" attributes="0"/>
+                      <Component id="labelEditMode" min="-2" max="-2" attributes="0"/>
                       <EmptySpace max="-2" attributes="0"/>
-                      <Component id="jLabelEdit" min="-2" max="-2" attributes="0"/>
+                      <Component id="labelEditModeState" min="-2" max="-2" attributes="0"/>
                       <EmptySpace type="unrelated" max="-2" attributes="0"/>
                       <Component id="btnSwitchEditMode" min="-2" max="-2" attributes="0"/>
                       <EmptySpace min="-2" pref="82" max="-2" attributes="0"/>
                       <Component id="btnUploadChanges" min="-2" max="-2" attributes="0"/>
                       <EmptySpace max="-2" attributes="0"/>
-                      <Component id="btnRevertChangesBatchEdit1" min="-2" max="-2" attributes="0"/>
+                      <Component id="btnRevertChangesBatchEdit" min="-2" max="-2" attributes="0"/>
                       <EmptySpace max="32767" attributes="0"/>
                       <Component id="btnAddRecords" min="-2" max="-2" attributes="0"/>
                       <EmptySpace max="-2" attributes="0"/>
@@ -572,12 +572,12 @@
                       <EmptySpace min="-2" pref="4" max="-2" attributes="0"/>
                       <Group type="103" groupAlignment="3" attributes="0">
                           <Component id="btnUploadChanges" alignment="3" min="-2" max="-2" attributes="0"/>
-                          <Component id="jLabel2" alignment="3" min="-2" max="-2" attributes="0"/>
+                          <Component id="labelEditMode" alignment="3" min="-2" max="-2" attributes="0"/>
                           <Component id="btnSwitchEditMode" alignment="3" min="-2" max="-2" attributes="0"/>
-                          <Component id="jLabelEdit" alignment="3" min="-2" max="-2" attributes="0"/>
+                          <Component id="labelEditModeState" alignment="3" min="-2" max="-2" attributes="0"/>
                           <Component id="btnBatchEdit" alignment="3" min="-2" max="-2" attributes="0"/>
                           <Component id="btnAddRecords" alignment="3" min="-2" max="-2" attributes="0"/>
-                          <Component id="btnRevertChangesBatchEdit1" alignment="3" min="-2" max="-2" attributes="0"/>
+                          <Component id="btnRevertChangesBatchEdit" alignment="3" min="-2" max="-2" attributes="0"/>
                       </Group>
                       <EmptySpace min="-2" pref="4" max="-2" attributes="0"/>
                   </Group>
@@ -623,22 +623,22 @@
                 <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="btnSwitchEditModeActionPerformed"/>
               </Events>
             </Component>
-            <Component class="javax.swing.JLabel" name="jLabelEdit">
+            <Component class="javax.swing.JLabel" name="labelEditModeState">
               <Properties>
                 <Property name="text" type="java.lang.String" value="OFF"/>
               </Properties>
             </Component>
-            <Component class="javax.swing.JLabel" name="jLabel2">
+            <Component class="javax.swing.JLabel" name="labelEditMode">
               <Properties>
                 <Property name="text" type="java.lang.String" value="Edit Mode:"/>
               </Properties>
             </Component>
-            <Component class="javax.swing.JButton" name="btnRevertChangesBatchEdit1">
+            <Component class="javax.swing.JButton" name="btnRevertChangesBatchEdit">
               <Properties>
                 <Property name="text" type="java.lang.String" value="Revert Changes"/>
               </Properties>
               <Events>
-                <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="btnRevertChangesBatchEdit1ActionPerformed"/>
+                <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="btnRevertChangesBatchEditActionPerformed"/>
               </Events>
             </Component>
           </SubComponents>

--- a/src/com/elle/ProjectManager/presentation/ProjectManagerWindow.java
+++ b/src/com/elle/ProjectManager/presentation/ProjectManagerWindow.java
@@ -2000,6 +2000,7 @@ public class ProjectManagerWindow extends JFrame implements ITableConstants {
         table.getModel().addTableModelListener(new TableModelListener() {  // add tableSelected model listener every time the tableSelected model reloaded
             @Override
             public void tableChanged(TableModelEvent e) {
+                
                 int row = e.getFirstRow();
                 int col = e.getColumn();
                 String tab = getSelectedTabName();
@@ -2008,21 +2009,34 @@ public class ProjectManagerWindow extends JFrame implements ITableConstants {
                 Object oldValue = data.getOldData()[row][col];
                 Object newValue = table.getModel().getValueAt(row, col);
 
-                // disable the upload changes button
-                btnUploadChanges.setEnabled(false);
-
                 // check that data is different
-                if (!newValue.equals(oldValue)) {
+                if(!newValue.equals(oldValue)){
 
                     String tableName = table.getName();
                     String columnName = table.getColumnName(col);
                     int id = (Integer) table.getModel().getValueAt(row, 0);
+                    
                     data.getNewData().add(new ModifiedData(tableName, columnName, newValue, id));
 
                     // color the cell
                     JTableCellRenderer cellRender = tabs.get(tab).getCellRenderer();
                     cellRender.getCells().get(col).add(row);
                     table.getColumnModel().getColumn(col).setCellRenderer(cellRender);
+                    
+                    // can upload or revert changes
+                    setEnabledEditingButtons(false, true, true);
+                }
+                
+                // if modified data then cancel button not enabled
+                else if(!data.getNewData().isEmpty()){
+                    // can upload or revert changes
+                    setEnabledEditingButtons(false, true, true);
+                }
+                
+                // there is no new modified data
+                else{
+                    // no changes to upload or revert (these options disabled)
+                    setEnabledEditingButtons(true, false, false);
                 }
             }
         });

--- a/src/com/elle/ProjectManager/presentation/ProjectManagerWindow.java
+++ b/src/com/elle/ProjectManager/presentation/ProjectManagerWindow.java
@@ -51,8 +51,8 @@ import java.util.Vector;
 public class ProjectManagerWindow extends JFrame implements ITableConstants {
 
     // Edit the version and date it was created for new archives and jars
-    private final String CREATION_DATE = "2015-09-23";
-    private final String VERSION = "0.8.8a";
+    private final String CREATION_DATE = "2015-10-01";
+    private final String VERSION = "0.9.0";
 
     // attributes
     private Map<String, Tab> tabs; // stores individual tabName information

--- a/src/com/elle/ProjectManager/presentation/ProjectManagerWindow.java
+++ b/src/com/elle/ProjectManager/presentation/ProjectManagerWindow.java
@@ -221,6 +221,11 @@ public class ProjectManagerWindow extends JFrame implements ITableConstants {
         tabs.get(TASKS_TABLE_NAME).setTableData(new ModifiedTableData(tasksTable));
         tabs.get(TASKFILES_TABLE_NAME).setTableData(new ModifiedTableData(task_filesTable));
         tabs.get(TASKNOTES_TABLE_NAME).setTableData(new ModifiedTableData(task_notesTable));
+        
+        // set all the tabs initially not in editing mode
+        tabs.get(TASKS_TABLE_NAME).setEditing(false);
+        tabs.get(TASKFILES_TABLE_NAME).setEditing(false);
+        tabs.get(TASKNOTES_TABLE_NAME).setEditing(false);
 
 //        // Call the initTableCellPopup method to initiate the Table Cell Popup window
 //        initTableCellPopup();

--- a/src/com/elle/ProjectManager/presentation/ProjectManagerWindow.java
+++ b/src/com/elle/ProjectManager/presentation/ProjectManagerWindow.java
@@ -21,8 +21,6 @@ import javax.swing.event.TableModelListener;
 import javax.swing.table.*;
 import javax.swing.text.AbstractDocument;
 import java.awt.*;
-import java.awt.event.ActionEvent;
-import java.awt.event.ActionListener;
 import java.awt.event.AdjustmentEvent;
 import java.awt.event.AdjustmentListener;
 import java.awt.event.KeyAdapter;
@@ -69,8 +67,13 @@ public class ProjectManagerWindow extends JFrame implements ITableConstants {
     private BatchEditWindow batchEditWindow;
     private EditDatabaseWindow editDatabaseWindow;
     private ReportWindow reportWindow;
+    
+    // colors - Edit mode labels
+    private Color editModeDefaultTextColor;
+    private Color editModeActiveTextColor;
+    
+    // Misc 
     private boolean addRecordWindowShow;
-
     private int addRecordLevel = 2;
     private int deleteRecordLevel = 2;
 

--- a/src/com/elle/ProjectManager/presentation/ProjectManagerWindow.java
+++ b/src/com/elle/ProjectManager/presentation/ProjectManagerWindow.java
@@ -153,6 +153,10 @@ public class ProjectManagerWindow extends JFrame implements ITableConstants {
 
         initComponents(); // generated code
 
+        // initialize the colors for the edit mode text
+        editModeActiveTextColor = new Color(44,122,22); //dark green
+        editModeDefaultTextColor = labelEditMode.getForeground();
+        
         // set names to tables (this was in tabbedPanelChanged method)
         tasksTable.setName(TASKS_TABLE_NAME);
         task_filesTable.setName(TASKFILES_TABLE_NAME);
@@ -478,9 +482,9 @@ public class ProjectManagerWindow extends JFrame implements ITableConstants {
         btnAddRecords = new javax.swing.JButton();
         btnUploadChanges = new javax.swing.JButton();
         btnSwitchEditMode = new javax.swing.JButton();
-        jLabelEdit = new javax.swing.JLabel();
-        jLabel2 = new javax.swing.JLabel();
-        btnRevertChangesBatchEdit1 = new javax.swing.JButton();
+        labelEditModeState = new javax.swing.JLabel();
+        labelEditMode = new javax.swing.JLabel();
+        btnRevertChangesBatchEdit = new javax.swing.JButton();
         jPanelSQL = new javax.swing.JPanel();
         jScrollPane2 = new javax.swing.JScrollPane();
         jTextAreaSQL = new javax.swing.JTextArea();
@@ -694,14 +698,14 @@ public class ProjectManagerWindow extends JFrame implements ITableConstants {
             }
         });
 
-        jLabelEdit.setText("OFF");
+        labelEditModeState.setText("OFF");
 
-        jLabel2.setText("Edit Mode:");
+        labelEditMode.setText("Edit Mode:");
 
-        btnRevertChangesBatchEdit1.setText("Revert Changes");
-        btnRevertChangesBatchEdit1.addActionListener(new java.awt.event.ActionListener() {
+        btnRevertChangesBatchEdit.setText("Revert Changes");
+        btnRevertChangesBatchEdit.addActionListener(new java.awt.event.ActionListener() {
             public void actionPerformed(java.awt.event.ActionEvent evt) {
-                btnRevertChangesBatchEdit1ActionPerformed(evt);
+                btnRevertChangesBatchEditActionPerformed(evt);
             }
         });
 
@@ -711,15 +715,15 @@ public class ProjectManagerWindow extends JFrame implements ITableConstants {
             jPanelEditLayout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
             .addGroup(jPanelEditLayout.createSequentialGroup()
                 .addContainerGap()
-                .addComponent(jLabel2)
+                .addComponent(labelEditMode)
                 .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
-                .addComponent(jLabelEdit)
+                .addComponent(labelEditModeState)
                 .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.UNRELATED)
                 .addComponent(btnSwitchEditMode)
                 .addGap(82, 82, 82)
                 .addComponent(btnUploadChanges, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
                 .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
-                .addComponent(btnRevertChangesBatchEdit1)
+                .addComponent(btnRevertChangesBatchEdit)
                 .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
                 .addComponent(btnAddRecords)
                 .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
@@ -732,12 +736,12 @@ public class ProjectManagerWindow extends JFrame implements ITableConstants {
                 .addGap(4, 4, 4)
                 .addGroup(jPanelEditLayout.createParallelGroup(javax.swing.GroupLayout.Alignment.BASELINE)
                     .addComponent(btnUploadChanges, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
-                    .addComponent(jLabel2)
+                    .addComponent(labelEditMode)
                     .addComponent(btnSwitchEditMode)
-                    .addComponent(jLabelEdit)
+                    .addComponent(labelEditModeState)
                     .addComponent(btnBatchEdit)
                     .addComponent(btnAddRecords)
-                    .addComponent(btnRevertChangesBatchEdit1))
+                    .addComponent(btnRevertChangesBatchEdit))
                 .addGap(4, 4, 4))
         );
 
@@ -1206,7 +1210,7 @@ public class ProjectManagerWindow extends JFrame implements ITableConstants {
         // reload modified tableSelected data with current tableSelected model
         data.reloadData();
 
-        makeTableEditable(jLabelEdit.getText().equals("OFF") ? true : false);
+        makeTableEditable(labelEditModeState.getText().equals("OFF") ? true : false);
 
         data.getNewData().clear();    // reset the arraylist to record future changes
         setLastUpdateTime();          // update time
@@ -1258,9 +1262,9 @@ public class ProjectManagerWindow extends JFrame implements ITableConstants {
 
         // this was the way it is being checked - with the label text
         // this checks the text and passes the opposite - ON = false to turn off
-        makeTableEditable(jLabelEdit.getText().equals("ON ") ? false : true);
+        makeTableEditable(labelEditModeState.getText().equals("ON ") ? false : true);
 
-        boolean editable = jLabelEdit.getText().equals("ON");
+        boolean editable = labelEditModeState.getText().equals("ON");
 
         tableCellPopupWindow.enableEdit(editable);
 
@@ -1279,13 +1283,13 @@ public class ProjectManagerWindow extends JFrame implements ITableConstants {
         boolean isBatchEditBtnVisible = tab.isBatchEditBtnVisible();
 
         if (makeTableEditable) {
-            jLabelEdit.setText("ON ");
+            labelEditModeState.setText("ON ");
             btnSwitchEditMode.setVisible(false);
             btnUploadChanges.setVisible(true);
             btnAddRecords.setVisible(false);
             btnBatchEdit.setVisible(false);
         } else {
-            jLabelEdit.setText("OFF");
+            labelEditModeState.setText("OFF");
             btnSwitchEditMode.setVisible(true);
             btnUploadChanges.setVisible(false);
             btnAddRecords.setVisible(isAddRecordsBtnVisible);
@@ -1306,7 +1310,7 @@ public class ProjectManagerWindow extends JFrame implements ITableConstants {
      * @param
      */
     public boolean getEditMode() {
-        boolean editable = jLabelEdit.getText().equals("ON");
+        boolean editable = labelEditModeState.getText().equals("ON");
         return editable;
     }
 
@@ -1335,7 +1339,7 @@ public class ProjectManagerWindow extends JFrame implements ITableConstants {
         labelRecords.setText(recordsLabel);
 
         // hide buttons if in edit mode
-        if (jLabelEdit.getText().equals("ON ")) {
+        if (labelEditModeState.getText().equals("ON ")) {
             btnAddRecords.setVisible(false);
             btnBatchEdit.setVisible(false);
         }
@@ -1714,9 +1718,9 @@ public class ProjectManagerWindow extends JFrame implements ITableConstants {
         }
     }//GEN-LAST:event_menuItemSQLCmdChkBxActionPerformed
 
-    private void btnRevertChangesBatchEdit1ActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_btnRevertChangesBatchEdit1ActionPerformed
+    private void btnRevertChangesBatchEditActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_btnRevertChangesBatchEditActionPerformed
         // TODO add your handling code here:
-    }//GEN-LAST:event_btnRevertChangesBatchEdit1ActionPerformed
+    }//GEN-LAST:event_btnRevertChangesBatchEditActionPerformed
 
     private void buttonFilteringTables(JTable table, String str){
         
@@ -1806,7 +1810,7 @@ public class ProjectManagerWindow extends JFrame implements ITableConstants {
                                     filterByDoubleClick(table);
                                 }
                             } else if (e.getClickCount() == 1) {
-                                if (jLabelEdit.getText().equals("ON ")) {
+                                if (labelEditModeState.getText().equals("ON ")) {
                                     selectAllText(e);
                                 }
                             }
@@ -1893,7 +1897,7 @@ public class ProjectManagerWindow extends JFrame implements ITableConstants {
 
                     // I believe this is meant to toggle edit mode
                     // so I passed the conditional
-                    makeTableEditable(jLabelEdit.getText().equals("ON ") ? false : true);
+                    makeTableEditable(labelEditModeState.getText().equals("ON ") ? false : true);
                 }
             }
         });
@@ -2107,7 +2111,7 @@ public class ProjectManagerWindow extends JFrame implements ITableConstants {
         KeyboardFocusManager.getCurrentKeyboardFocusManager().addKeyEventDispatcher(new KeyEventDispatcher() {
             @Override
             public boolean dispatchKeyEvent(KeyEvent e) {
-                if (jLabelEdit.getText().equals("ON ")) {
+                if (labelEditModeState.getText().equals("ON ")) {
                     if (e.getKeyCode() == KeyEvent.VK_TAB) {
                         if (e.getComponent() instanceof JTable) {
                             JTable table = (JTable) e.getComponent();
@@ -2237,7 +2241,7 @@ public class ProjectManagerWindow extends JFrame implements ITableConstants {
 
                 boolean disable = !tableCellPopupWindow.getWindowPopup();
 
-                if (jLabelEdit.getText().equals("ON")) {
+                if (labelEditModeState.getText().equals("ON")) {
 
                     table.setEnabled(disable);
 
@@ -2257,7 +2261,7 @@ public class ProjectManagerWindow extends JFrame implements ITableConstants {
 
                 boolean disable = !tableCellPopupWindow.getWindowPopup();
 
-                if (jLabelEdit.getText().equals("ON")) {
+                if (labelEditModeState.getText().equals("ON")) {
 
                     table.setEnabled(disable);
 
@@ -2275,7 +2279,7 @@ public class ProjectManagerWindow extends JFrame implements ITableConstants {
 
                 boolean disable = !tableCellPopupWindow.getWindowPopup();
 
-                if (jLabelEdit.getText().equals("ON")) {
+                if (labelEditModeState.getText().equals("ON")) {
 
                     table.setEnabled(disable);
 
@@ -2591,13 +2595,11 @@ public class ProjectManagerWindow extends JFrame implements ITableConstants {
     private javax.swing.JButton btnClearAllFilter;
     private javax.swing.JButton btnCloseSQL;
     private javax.swing.JButton btnEnterSQL;
-    private javax.swing.JButton btnRevertChangesBatchEdit1;
+    private javax.swing.JButton btnRevertChangesBatchEdit;
     private javax.swing.JButton btnSearch;
     private javax.swing.JButton btnSwitchEditMode;
     private javax.swing.JButton btnUploadChanges;
     private javax.swing.JComboBox comboBoxSearch;
-    private javax.swing.JLabel jLabel2;
-    private javax.swing.JLabel jLabelEdit;
     private javax.swing.JPanel jPanel1;
     private javax.swing.JPanel jPanel5;
     private javax.swing.JPanel jPanelEdit;
@@ -2608,6 +2610,8 @@ public class ProjectManagerWindow extends JFrame implements ITableConstants {
     private javax.swing.JScrollPane jScrollPane4;
     private javax.swing.JTabbedPane jTabbedPane1;
     private javax.swing.JTextArea jTextAreaSQL;
+    private javax.swing.JLabel labelEditMode;
+    private javax.swing.JLabel labelEditModeState;
     private javax.swing.JLabel labelRecords;
     private javax.swing.JLabel labelTimeLastUpdate;
     private javax.swing.JMenuBar menuBar;

--- a/src/com/elle/ProjectManager/presentation/ProjectManagerWindow.java
+++ b/src/com/elle/ProjectManager/presentation/ProjectManagerWindow.java
@@ -1215,6 +1215,9 @@ public class ProjectManagerWindow extends JFrame implements ITableConstants {
 
         data.getNewData().clear();    // reset the arraylist to record future changes
         setLastUpdateTime();          // update time
+        
+        // no changes to upload or revert
+        setEnabledEditingButtons(true, false, false);
     }
 
     private void menuItemRepBugSuggActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_menuItemRepBugSuggActionPerformed

--- a/src/com/elle/ProjectManager/presentation/ProjectManagerWindow.java
+++ b/src/com/elle/ProjectManager/presentation/ProjectManagerWindow.java
@@ -1849,28 +1849,50 @@ public class ProjectManagerWindow extends JFrame implements ITableConstants {
                                 }
                             }
                         } // end if left mouse clicks
+                        
                         // if right mouse clicks
-                        else if (SwingUtilities.isRightMouseButton(e)) {
-                            if (e.getClickCount() == 2) {
+                        else if(SwingUtilities.isRightMouseButton(e)){
+                            if (e.getClickCount() == 2 ) {
+                                
+                                Tab tab = tabs.get(table.getName());
+                                
+                                // check if this tab is editing or if allowed editing
+                                boolean thisTabIsEditing = tab.isEditing();
+                                boolean noTabIsEditing = !isTabEditing();
+                                
+                                if(thisTabIsEditing || noTabIsEditing){
+                                
+                                    // set the states for this tab
+                                    tab.setEditing(true);
+                                    makeTableEditable(true);
+                                    setEnabledEditingButtons(true, true, true);
+                                    setBatchEditButtonStates(tab);
+                                    
+                                    // set the color of the edit mode text
+                                    editModeTextColor(tab.isEditing());
 
-                                // make tableSelected editable
-                                makeTableEditable(true);
+                                    // get selected cell for editing
+                                    int columnIndex = table.columnAtPoint(e.getPoint()); // this returns the column index
+                                    int rowIndex = table.rowAtPoint(e.getPoint()); // this returns the rowIndex index
+                                    if (rowIndex != -1 && columnIndex != -1) {
 
-                                // get selected cell
-                                int columnIndex = table.columnAtPoint(e.getPoint()); // this returns the column index
-                                int rowIndex = table.rowAtPoint(e.getPoint()); // this returns the rowIndex index
-                                if (rowIndex != -1 && columnIndex != -1) {
+                                        // make it the active editing cell
+                                        table.changeSelection(rowIndex, columnIndex, false, false);
 
-                                    // make it the active editing cell
-                                    table.changeSelection(rowIndex, columnIndex, false, false);
+                                        selectAllText(e);
+                                        
+                                        // if cell is being edited
+                                        // cannot cancel or upload or revert
+                                        setEnabledEditingButtons(false, false, false);
+                
 
-                                    selectAllText(e);
-
-                                } // end not null condition
-
+                                    } // end not null condition
+                                
+                                } // end of is tab editing conditions
+                                
                             } // end if 2 clicks 
                         } // end if right mouse clicks
-
+                        
                     }// end mouseClicked
 
                     private void selectAllText(MouseEvent e) {// Select all text inside jTextField

--- a/src/com/elle/ProjectManager/presentation/ProjectManagerWindow.java
+++ b/src/com/elle/ProjectManager/presentation/ProjectManagerWindow.java
@@ -1809,7 +1809,9 @@ public class ProjectManagerWindow extends JFrame implements ITableConstants {
     }//GEN-LAST:event_menuItemSQLCmdChkBxActionPerformed
 
     private void btnRevertChangesActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_btnRevertChangesActionPerformed
-        // TODO add your handling code here:
+        
+        revertChanges();
+        
     }//GEN-LAST:event_btnRevertChangesActionPerformed
 
     private void buttonFilteringTables(JTable table, String str){

--- a/src/com/elle/ProjectManager/presentation/ProjectManagerWindow.java
+++ b/src/com/elle/ProjectManager/presentation/ProjectManagerWindow.java
@@ -1261,9 +1261,42 @@ public class ProjectManagerWindow extends JFrame implements ITableConstants {
 
     private void btnSwitchEditModeActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_btnSwitchEditModeActionPerformed
 
-        // this was the way it is being checked - with the label text
-        // this checks the text and passes the opposite - ON = false to turn off
-        makeTableEditable(labelEditModeState.getText().equals("ON ") ? false : true);
+         // get selected tab
+        String tabName = getSelectedTabName();
+        Tab tab = tabs.get(tabName);
+        
+        // get whether  this tab is currently editing
+        boolean editing = tab.isEditing();
+        
+        // if tab is editing then it is switching off
+        if(editing){
+            
+            // set the states for this tab
+            tab.setEditing(false);
+            makeTableEditable(false);
+            setEnabledEditingButtons(true, true, true);
+            btnAddRecords.setEnabled(true);
+            btnSwitchEditMode.setEnabled(true);
+            setBatchEditButtonStates(tab);
+
+            // set the color of the edit mode text
+            editModeTextColor(tab.isEditing());
+        
+        }
+        
+        // if tab is not editing then it is switching on
+        else{
+            
+            // set the states for this tab
+            tab.setEditing(true);
+            makeTableEditable(true);
+            setEnabledEditingButtons(true, false, false);
+            setBatchEditButtonStates(tab);
+
+        }
+        
+        // set the color of the edit mode text
+        editModeTextColor(!editing);
 
         boolean editable = labelEditModeState.getText().equals("ON");
 
@@ -2585,6 +2618,149 @@ public class ProjectManagerWindow extends JFrame implements ITableConstants {
             }
         }
         return sqlDelete;
+    }
+    
+    
+    /******* added methods *******************************/
+    
+    public JPanel getAddPanel_control() {
+        return addPanel_control;
+    }
+
+    public JPanel getjPanel5() {
+        return jPanel5;
+    }
+
+    public JPanel getjPanelSQL() {
+        return jPanelSQL;
+    }
+
+    public JPanel getSearchPanel() {
+        return searchPanel;
+    }
+    
+    /**
+     * setBatchEditButtonStates
+     * Sets the batch edit button enabled if editing allowed for that tab
+     * and disabled if editing is not allowed for that tab
+     * @param selectedTab // this is the editing tab
+     */
+    private void setBatchEditButtonStates(Tab selectedTab) {
+        
+        for (Map.Entry<String, Tab> entry : tabs.entrySet())
+        {
+            Tab tab = tabs.get(entry.getKey());
+            
+            // if selectedTab is editing, that means the switch button was pressed
+            if(selectedTab.isEditing()){
+                if (tab == selectedTab){
+                    if(selectedTab.isBatchEditWindowOpen()){
+                        btnBatchEdit.setEnabled(false);
+                    }
+                    else{
+                        tab.setBatchEditBtnEnabled(true);
+                    }
+                }
+                else{
+                    tab.setBatchEditBtnEnabled(false);
+                }
+            }
+            else{
+                tab.setBatchEditBtnEnabled(true);
+            }
+        }
+    }
+
+    /**
+     * getBtnBatchEdit
+     * @return 
+     */
+    public JButton getBtnBatchEdit() {
+        return btnBatchEdit;
+    }
+
+    public BatchEditWindow getBatchEditWindow() {
+        return batchEditWindow;
+    }
+    
+    /**
+     * isTabEditing
+     * This method returns true or false whether a tab is in editing mode or not
+     * @return boolean isEditing 
+     */
+    public boolean isTabEditing(){
+        
+        boolean isEditing = false;
+        
+        for (Map.Entry<String, Tab> entry : tabs.entrySet())
+        {
+            Tab tab = tabs.get(entry.getKey());
+            isEditing = tab.isEditing();
+            
+            // if editing break and return true
+            if(isEditing){
+                break;
+            }
+        }
+        
+        return isEditing;
+    }
+    
+    /**
+     * setEnabledEditingButtons
+     * sets the editing buttons enabled 
+     * @param switchBtnEnabled
+     * @param uploadEnabled
+     * @param revertEnabled 
+     */
+    public void setEnabledEditingButtons(boolean switchBtnEnabled, boolean uploadEnabled, boolean revertEnabled){
+        
+        // the three editing buttons (cancel, upload, revert)
+        btnSwitchEditMode.setEnabled(switchBtnEnabled);
+        btnUploadChanges.setEnabled(uploadEnabled);
+        btnRevertChanges.setEnabled(revertEnabled);
+    }
+    
+    /**
+     * revertChanges
+     * used to revert changes of modified data to original data
+     */
+    public void revertChanges(){
+        
+        String tabName = getSelectedTabName();
+        Tab tab = tabs.get(tabName);
+        JTable table = tab.getTable();
+        ModifiedTableData modifiedTableData = tab.getTableData();
+        modifiedTableData.getNewData().clear();  // clear any stored changes (new data)
+        loadTable(table); // reverts the model back
+        modifiedTableData.reloadData();  // reloads data of new table (old data) to compare with new changes (new data)
+        
+        // no changes to upload or revert
+        setEnabledEditingButtons(true, false, false);
+        
+        // set the color of the edit mode text
+        editModeTextColor(tab.isEditing());
+    }
+    
+    /**
+     * editModeTextColor
+     * This method changes the color of the edit mode text
+     * If edit mode is active then the text is green 
+     * and if it is not active then the text is the default color (black)
+     */
+    public void editModeTextColor(boolean editing){
+        
+        // if editing
+        if(editing){
+            labelEditMode.setForeground(editModeActiveTextColor);
+            labelEditModeState.setForeground(editModeActiveTextColor);
+        }
+        
+        // else not editing
+        else {
+            labelEditMode.setForeground(editModeDefaultTextColor);
+            labelEditModeState.setForeground(editModeDefaultTextColor);
+        }
     }
 
     // @formatter:off

--- a/src/com/elle/ProjectManager/presentation/ProjectManagerWindow.java
+++ b/src/com/elle/ProjectManager/presentation/ProjectManagerWindow.java
@@ -176,11 +176,9 @@ public class ProjectManagerWindow extends JFrame implements ITableConstants {
         jPanelSQL.setVisible(false);
         btnEnterSQL.setVisible(true);
         btnCancelSQL.setVisible(true);
-        btnCancelEditMode.setVisible(false);
         btnBatchEdit.setVisible(true);
         jTextAreaSQL.setVisible(true);
         jPanelEdit.setVisible(true);
-        panelBatchEditButtons.setVisible(false);
 
         // add filters for each tableSelected
         // must be before setting ColumnPopupMenu because this is its parameter
@@ -476,19 +474,16 @@ public class ProjectManagerWindow extends JFrame implements ITableConstants {
         btnBatchEdit = new javax.swing.JButton();
         btnAddRecords = new javax.swing.JButton();
         btnUploadChanges = new javax.swing.JButton();
-        btnCancelEditMode = new javax.swing.JButton();
         btnSwitchEditMode = new javax.swing.JButton();
         jLabelEdit = new javax.swing.JLabel();
         jLabel2 = new javax.swing.JLabel();
+        btnRevertChangesBatchEdit1 = new javax.swing.JButton();
         jPanelSQL = new javax.swing.JPanel();
         jScrollPane2 = new javax.swing.JScrollPane();
         jTextAreaSQL = new javax.swing.JTextArea();
         btnEnterSQL = new javax.swing.JButton();
         btnCancelSQL = new javax.swing.JButton();
         btnCloseSQL = new javax.swing.JButton();
-        panelBatchEditButtons = new javax.swing.JPanel();
-        btnRevertChangesBatchEdit = new javax.swing.JButton();
-        btnUploadChangesBatchEdit = new javax.swing.JButton();
         addPanel_control = new javax.swing.JPanel();
         jPanel1 = new javax.swing.JPanel();
         labelRecords = new javax.swing.JLabel();
@@ -689,13 +684,6 @@ public class ProjectManagerWindow extends JFrame implements ITableConstants {
             }
         });
 
-        btnCancelEditMode.setText("Cancel");
-        btnCancelEditMode.addActionListener(new java.awt.event.ActionListener() {
-            public void actionPerformed(java.awt.event.ActionEvent evt) {
-                btnCancelEditModeActionPerformed(evt);
-            }
-        });
-
         btnSwitchEditMode.setText("Switch");
         btnSwitchEditMode.addActionListener(new java.awt.event.ActionListener() {
             public void actionPerformed(java.awt.event.ActionEvent evt) {
@@ -706,6 +694,13 @@ public class ProjectManagerWindow extends JFrame implements ITableConstants {
         jLabelEdit.setText("OFF");
 
         jLabel2.setText("Edit Mode:");
+
+        btnRevertChangesBatchEdit1.setText("Revert Changes");
+        btnRevertChangesBatchEdit1.addActionListener(new java.awt.event.ActionListener() {
+            public void actionPerformed(java.awt.event.ActionEvent evt) {
+                btnRevertChangesBatchEdit1ActionPerformed(evt);
+            }
+        });
 
         javax.swing.GroupLayout jPanelEditLayout = new javax.swing.GroupLayout(jPanelEdit);
         jPanelEdit.setLayout(jPanelEditLayout);
@@ -718,10 +713,10 @@ public class ProjectManagerWindow extends JFrame implements ITableConstants {
                 .addComponent(jLabelEdit)
                 .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.UNRELATED)
                 .addComponent(btnSwitchEditMode)
-                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
-                .addComponent(btnCancelEditMode)
-                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
+                .addGap(82, 82, 82)
                 .addComponent(btnUploadChanges, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
+                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
+                .addComponent(btnRevertChangesBatchEdit1)
                 .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
                 .addComponent(btnAddRecords)
                 .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
@@ -737,9 +732,9 @@ public class ProjectManagerWindow extends JFrame implements ITableConstants {
                     .addComponent(jLabel2)
                     .addComponent(btnSwitchEditMode)
                     .addComponent(jLabelEdit)
-                    .addComponent(btnCancelEditMode)
                     .addComponent(btnBatchEdit)
-                    .addComponent(btnAddRecords))
+                    .addComponent(btnAddRecords)
+                    .addComponent(btnRevertChangesBatchEdit1))
                 .addGap(4, 4, 4))
         );
 
@@ -807,50 +802,11 @@ public class ProjectManagerWindow extends JFrame implements ITableConstants {
                 .addGap(4, 4, 4))
         );
 
-        panelBatchEditButtons.setPreferredSize(new java.awt.Dimension(636, 180));
-
-        btnRevertChangesBatchEdit.setText("Revert Changes");
-        btnRevertChangesBatchEdit.addActionListener(new java.awt.event.ActionListener() {
-            public void actionPerformed(java.awt.event.ActionEvent evt) {
-                btnRevertChangesBatchEditActionPerformed(evt);
-            }
-        });
-
-        btnUploadChangesBatchEdit.setText("Upload Changes");
-        btnUploadChangesBatchEdit.setMaximumSize(new java.awt.Dimension(95, 30));
-        btnUploadChangesBatchEdit.setMinimumSize(new java.awt.Dimension(95, 30));
-        btnUploadChangesBatchEdit.addActionListener(new java.awt.event.ActionListener() {
-            public void actionPerformed(java.awt.event.ActionEvent evt) {
-                btnUploadChangesBatchEditActionPerformed(evt);
-            }
-        });
-
-        javax.swing.GroupLayout panelBatchEditButtonsLayout = new javax.swing.GroupLayout(panelBatchEditButtons);
-        panelBatchEditButtons.setLayout(panelBatchEditButtonsLayout);
-        panelBatchEditButtonsLayout.setHorizontalGroup(
-            panelBatchEditButtonsLayout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
-            .addGroup(panelBatchEditButtonsLayout.createSequentialGroup()
-                .addContainerGap(javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
-                .addComponent(btnUploadChangesBatchEdit, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
-                .addGap(18, 18, 18)
-                .addComponent(btnRevertChangesBatchEdit)
-                .addContainerGap(javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE))
-        );
-        panelBatchEditButtonsLayout.setVerticalGroup(
-            panelBatchEditButtonsLayout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
-            .addGroup(panelBatchEditButtonsLayout.createSequentialGroup()
-                .addContainerGap(javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
-                .addGroup(panelBatchEditButtonsLayout.createParallelGroup(javax.swing.GroupLayout.Alignment.BASELINE)
-                    .addComponent(btnUploadChangesBatchEdit, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
-                    .addComponent(btnRevertChangesBatchEdit)))
-        );
-
         javax.swing.GroupLayout jPanel5Layout = new javax.swing.GroupLayout(jPanel5);
         jPanel5.setLayout(jPanel5Layout);
         jPanel5Layout.setHorizontalGroup(
             jPanel5Layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
             .addComponent(jPanelEdit, javax.swing.GroupLayout.DEFAULT_SIZE, 823, Short.MAX_VALUE)
-            .addComponent(panelBatchEditButtons, javax.swing.GroupLayout.DEFAULT_SIZE, 823, Short.MAX_VALUE)
             .addGroup(javax.swing.GroupLayout.Alignment.TRAILING, jPanel5Layout.createSequentialGroup()
                 .addContainerGap()
                 .addComponent(jPanelSQL, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
@@ -863,9 +819,7 @@ public class ProjectManagerWindow extends JFrame implements ITableConstants {
                 .addComponent(tabbedPanel, javax.swing.GroupLayout.PREFERRED_SIZE, 349, javax.swing.GroupLayout.PREFERRED_SIZE)
                 .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
                 .addComponent(jPanelEdit, javax.swing.GroupLayout.PREFERRED_SIZE, 37, javax.swing.GroupLayout.PREFERRED_SIZE)
-                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
-                .addComponent(panelBatchEditButtons, javax.swing.GroupLayout.PREFERRED_SIZE, 33, javax.swing.GroupLayout.PREFERRED_SIZE)
-                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
+                .addGap(12, 12, 12)
                 .addComponent(jPanelSQL, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
                 .addGap(0, 0, 0))
         );
@@ -945,7 +899,7 @@ public class ProjectManagerWindow extends JFrame implements ITableConstants {
                 .addComponent(textFieldForSearch, javax.swing.GroupLayout.PREFERRED_SIZE, 141, javax.swing.GroupLayout.PREFERRED_SIZE)
                 .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
                 .addComponent(btnSearch)
-                .addContainerGap(92, Short.MAX_VALUE))
+                .addContainerGap(151, Short.MAX_VALUE))
         );
         searchPanelLayout.setVerticalGroup(
             searchPanelLayout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
@@ -956,7 +910,7 @@ public class ProjectManagerWindow extends JFrame implements ITableConstants {
                     .addComponent(comboBoxSearch, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
                     .addComponent(textFieldForSearch, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
                     .addComponent(btnSearch))
-                .addGap(0, 33, Short.MAX_VALUE))
+                .addGap(0, 38, Short.MAX_VALUE))
         );
 
         javax.swing.GroupLayout addPanel_controlLayout = new javax.swing.GroupLayout(addPanel_control);
@@ -968,12 +922,12 @@ public class ProjectManagerWindow extends JFrame implements ITableConstants {
                 .addComponent(searchPanel, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
                 .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
                 .addComponent(jPanel1, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
-                .addContainerGap(122, Short.MAX_VALUE))
+                .addContainerGap(123, Short.MAX_VALUE))
         );
         addPanel_controlLayout.setVerticalGroup(
             addPanel_controlLayout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
             .addGroup(addPanel_controlLayout.createSequentialGroup()
-                .addGap(0, 9, Short.MAX_VALUE)
+                .addGap(0, 5, Short.MAX_VALUE)
                 .addGroup(addPanel_controlLayout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
                     .addComponent(jPanel1, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
                     .addComponent(searchPanel, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)))
@@ -1325,14 +1279,12 @@ public class ProjectManagerWindow extends JFrame implements ITableConstants {
             jLabelEdit.setText("ON ");
             btnSwitchEditMode.setVisible(false);
             btnUploadChanges.setVisible(true);
-            btnCancelEditMode.setVisible(true);
             btnAddRecords.setVisible(false);
             btnBatchEdit.setVisible(false);
         } else {
             jLabelEdit.setText("OFF");
             btnSwitchEditMode.setVisible(true);
             btnUploadChanges.setVisible(false);
-            btnCancelEditMode.setVisible(false);
             btnAddRecords.setVisible(isAddRecordsBtnVisible);
             btnBatchEdit.setVisible(isBatchEditBtnVisible);
         }
@@ -1344,19 +1296,6 @@ public class ProjectManagerWindow extends JFrame implements ITableConstants {
             model.setCellEditable(makeTableEditable);
         }
     }
-
-    /**
-     * btnCancelEditModeActionPerformed
-     *
-     * @param evt
-     */
-    private void btnCancelEditModeActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_btnCancelEditModeActionPerformed
-
-        makeTableEditable(false); // exit edit mode;
-
-        tableCellPopupWindow.disableEdit(true);
-
-    }//GEN-LAST:event_btnCancelEditModeActionPerformed
 
     /**
      * getEditMode on or off
@@ -1403,7 +1342,6 @@ public class ProjectManagerWindow extends JFrame implements ITableConstants {
         batchEditWindow = new BatchEditWindow();
         batchEditWindow.setVisible(true);
         jPanelEdit.setVisible(false);
-        panelBatchEditButtons.setVisible(true);
     }//GEN-LAST:event_btnBatchEditActionPerformed
 
     private void menuItemManageDBsActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_menuItemManageDBsActionPerformed
@@ -1773,19 +1711,9 @@ public class ProjectManagerWindow extends JFrame implements ITableConstants {
         }
     }//GEN-LAST:event_menuItemSQLCmdChkBxActionPerformed
 
-    private void btnRevertChangesBatchEditActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_btnRevertChangesBatchEditActionPerformed
-        String tabName = getSelectedTabName();
-        Tab tab = tabs.get(tabName);
-        JTable table = tab.getTable();
-        ModifiedTableData modifiedTableData = tab.getTableData();
-        modifiedTableData.getNewData().clear();  // clear any stored changes (new data)
-        loadTable(table); // reverts the model back
-        modifiedTableData.reloadData();  // reloads data of new table (old data) to compare with new changes (new data)
-    }//GEN-LAST:event_btnRevertChangesBatchEditActionPerformed
-
-    private void btnUploadChangesBatchEditActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_btnUploadChangesBatchEditActionPerformed
-        uploadChanges();  // upload changes to database
-    }//GEN-LAST:event_btnUploadChangesBatchEditActionPerformed
+    private void btnRevertChangesBatchEdit1ActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_btnRevertChangesBatchEdit1ActionPerformed
+        // TODO add your handling code here:
+    }//GEN-LAST:event_btnRevertChangesBatchEdit1ActionPerformed
 
     private void buttonFilteringTables(JTable table, String str){
         
@@ -2367,7 +2295,6 @@ public class ProjectManagerWindow extends JFrame implements ITableConstants {
         btnAddRecords.setEnabled(disable);
         btnBatchEdit.setEnabled(disable);
         btnClearAllFilter.setEnabled(disable);
-        btnCancelEditMode.setEnabled(disable);
         btnSearch.setEnabled(disable);
         btnSwitchEditMode.setEnabled(disable);
         btnUploadChanges.setEnabled(disable);
@@ -2437,10 +2364,6 @@ public class ProjectManagerWindow extends JFrame implements ITableConstants {
 
     public JPanel getjPanelEdit() {
         return jPanelEdit;
-    }
-
-    public JPanel getPanelBatchEditButtons() {
-        return panelBatchEditButtons;
     }
 
     /**
@@ -2661,16 +2584,14 @@ public class ProjectManagerWindow extends JFrame implements ITableConstants {
     private javax.swing.JPanel addPanel_control;
     private javax.swing.JButton btnAddRecords;
     private javax.swing.JButton btnBatchEdit;
-    private javax.swing.JButton btnCancelEditMode;
     private javax.swing.JButton btnCancelSQL;
     private javax.swing.JButton btnClearAllFilter;
     private javax.swing.JButton btnCloseSQL;
     private javax.swing.JButton btnEnterSQL;
-    private javax.swing.JButton btnRevertChangesBatchEdit;
+    private javax.swing.JButton btnRevertChangesBatchEdit1;
     private javax.swing.JButton btnSearch;
     private javax.swing.JButton btnSwitchEditMode;
     private javax.swing.JButton btnUploadChanges;
-    private javax.swing.JButton btnUploadChangesBatchEdit;
     private javax.swing.JComboBox comboBoxSearch;
     private javax.swing.JLabel jLabel2;
     private javax.swing.JLabel jLabelEdit;
@@ -2714,7 +2635,6 @@ public class ProjectManagerWindow extends JFrame implements ITableConstants {
     private javax.swing.JMenu menuSelectConn;
     private javax.swing.JMenu menuTools;
     private javax.swing.JMenu menuView;
-    private javax.swing.JPanel panelBatchEditButtons;
     private javax.swing.JPanel searchPanel;
     private javax.swing.JTabbedPane tabbedPanel;
     private javax.swing.JTable task_filesTable;

--- a/src/com/elle/ProjectManager/presentation/ProjectManagerWindow.java
+++ b/src/com/elle/ProjectManager/presentation/ProjectManagerWindow.java
@@ -1926,9 +1926,8 @@ public class ProjectManagerWindow extends JFrame implements ITableConstants {
                                     filterByDoubleClick(table);
                                 }
                             } else if (e.getClickCount() == 1) {
-                                if (labelEditModeState.getText().equals("ON ")) {
-                                    selectAllText(e);
-                                }
+                                // do nothing
+                                // used to select rows or cells
                             }
                         } // end if left mouse clicks
                         

--- a/src/com/elle/ProjectManager/presentation/ProjectManagerWindow.java
+++ b/src/com/elle/ProjectManager/presentation/ProjectManagerWindow.java
@@ -186,6 +186,7 @@ public class ProjectManagerWindow extends JFrame implements ITableConstants {
         btnBatchEdit.setVisible(true);
         jTextAreaSQL.setVisible(true);
         jPanelEdit.setVisible(true);
+        btnRevertChanges.setVisible(false);
 
         // add filters for each tableSelected
         // must be before setting ColumnPopupMenu because this is its parameter
@@ -484,7 +485,7 @@ public class ProjectManagerWindow extends JFrame implements ITableConstants {
         btnSwitchEditMode = new javax.swing.JButton();
         labelEditModeState = new javax.swing.JLabel();
         labelEditMode = new javax.swing.JLabel();
-        btnRevertChangesBatchEdit = new javax.swing.JButton();
+        btnRevertChanges = new javax.swing.JButton();
         jPanelSQL = new javax.swing.JPanel();
         jScrollPane2 = new javax.swing.JScrollPane();
         jTextAreaSQL = new javax.swing.JTextArea();
@@ -702,10 +703,10 @@ public class ProjectManagerWindow extends JFrame implements ITableConstants {
 
         labelEditMode.setText("Edit Mode:");
 
-        btnRevertChangesBatchEdit.setText("Revert Changes");
-        btnRevertChangesBatchEdit.addActionListener(new java.awt.event.ActionListener() {
+        btnRevertChanges.setText("Revert Changes");
+        btnRevertChanges.addActionListener(new java.awt.event.ActionListener() {
             public void actionPerformed(java.awt.event.ActionEvent evt) {
-                btnRevertChangesBatchEditActionPerformed(evt);
+                btnRevertChangesActionPerformed(evt);
             }
         });
 
@@ -723,7 +724,7 @@ public class ProjectManagerWindow extends JFrame implements ITableConstants {
                 .addGap(82, 82, 82)
                 .addComponent(btnUploadChanges, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
                 .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
-                .addComponent(btnRevertChangesBatchEdit)
+                .addComponent(btnRevertChanges)
                 .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
                 .addComponent(btnAddRecords)
                 .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
@@ -741,7 +742,7 @@ public class ProjectManagerWindow extends JFrame implements ITableConstants {
                     .addComponent(labelEditModeState)
                     .addComponent(btnBatchEdit)
                     .addComponent(btnAddRecords)
-                    .addComponent(btnRevertChangesBatchEdit))
+                    .addComponent(btnRevertChanges))
                 .addGap(4, 4, 4))
         );
 
@@ -1718,9 +1719,9 @@ public class ProjectManagerWindow extends JFrame implements ITableConstants {
         }
     }//GEN-LAST:event_menuItemSQLCmdChkBxActionPerformed
 
-    private void btnRevertChangesBatchEditActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_btnRevertChangesBatchEditActionPerformed
+    private void btnRevertChangesActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_btnRevertChangesActionPerformed
         // TODO add your handling code here:
-    }//GEN-LAST:event_btnRevertChangesBatchEditActionPerformed
+    }//GEN-LAST:event_btnRevertChangesActionPerformed
 
     private void buttonFilteringTables(JTable table, String str){
         
@@ -2595,7 +2596,7 @@ public class ProjectManagerWindow extends JFrame implements ITableConstants {
     private javax.swing.JButton btnClearAllFilter;
     private javax.swing.JButton btnCloseSQL;
     private javax.swing.JButton btnEnterSQL;
-    private javax.swing.JButton btnRevertChangesBatchEdit;
+    private javax.swing.JButton btnRevertChanges;
     private javax.swing.JButton btnSearch;
     private javax.swing.JButton btnSwitchEditMode;
     private javax.swing.JButton btnUploadChanges;

--- a/src/com/elle/ProjectManager/presentation/ProjectManagerWindow.java
+++ b/src/com/elle/ProjectManager/presentation/ProjectManagerWindow.java
@@ -2249,11 +2249,10 @@ public class ProjectManagerWindow extends JFrame implements ITableConstants {
         KeyboardFocusManager.getCurrentKeyboardFocusManager().addKeyEventDispatcher(new KeyEventDispatcher() {
             @Override
             public boolean dispatchKeyEvent(KeyEvent e) {
-                if (labelEditModeState.getText().equals("ON ")) {
-                    if (e.getKeyCode() == KeyEvent.VK_TAB) {
+                 if (e.getKeyCode() == KeyEvent.VK_TAB) {
+                    if (labelEditModeState.getText().equals("ON ")) {
                         if (e.getComponent() instanceof JTable) {
                             JTable table = (JTable) e.getComponent();
-                            table.setFocusTraversalKeysEnabled(false);
                             int row = table.getSelectedRow();
                             int column = table.getSelectedColumn();
                             if (column == table.getRowCount() || column == 0) {
@@ -2265,11 +2264,19 @@ public class ProjectManagerWindow extends JFrame implements ITableConstants {
                                 selectCom.requestFocusInWindow();
                                 selectCom.selectAll();
                             }
+                            
+                            // if table cell is editing 
+                            // then the editing buttons should not be enabled
+                            if(table.isEditing()){
+                                setEnabledEditingButtons(false, false, false);
+                            }
                         }
-
-                    } else if (e.getKeyCode() == KeyEvent.VK_D && e.isControlDown()) {
-                        // Default Date input with today's date
-                        System.out.print("control d");
+                    }
+                    
+                } 
+                
+                else if (e.getKeyCode() == KeyEvent.VK_D && e.isControlDown()) {
+                    if (labelEditModeState.getText().equals("ON ")) {                       // Default Date input with today's date
                         JTable table = (JTable) e.getComponent().getParent();
                         int column = table.getSelectedColumn();
                         if (table.getColumnName(column).toLowerCase().contains("date")) {
@@ -2285,60 +2292,59 @@ public class ProjectManagerWindow extends JFrame implements ITableConstants {
                                 selectCom.setText(today);
                             }
                         }
-                    } else if (e.getKeyCode() == KeyEvent.VK_ENTER) {
+                    }
+                }
+                
+                else if (e.getKeyCode() == KeyEvent.VK_ENTER) {
+                    if (e.getComponent() instanceof JTable) {
+                        JTable table = (JTable)e.getComponent();
 
-                        if (e.getComponent() instanceof JTable) {
-                            JTable table = (JTable) e.getComponent();
-                            table.setFocusTraversalKeysEnabled(false);
+                        // make sure in editing mode
+                        if(labelEditModeState.getText().equals("ON ") 
+                                && !table.isEditing() 
+                                && e.getID() == KeyEvent.KEY_PRESSED){
 
-                            // make sure in editing mode
-                            if (!table.isEditing()
-                                    && e.getID() == KeyEvent.KEY_PRESSED) {
-
+                            // only show popup if there are changes to upload or revert
+                            if(btnUploadChanges.isEnabled() || btnRevertChanges.isEnabled()){
                                 // if finished display dialog box
                                 // Upload Changes? Yes or No?
                                 Object[] options = {"Commit", "Revert"};  // the titles of buttons
 
-                                // store selected rowIndex before the tableSelected is refreshed
+                                // store selected rowIndex before the table is refreshed
                                 int rowIndex = table.getSelectedRow();
 
-                                int selectedOption = JOptionPane.showOptionDialog(ProjectManagerWindow.getInstance(),
+                                int selectedOption = JOptionPane.showOptionDialog(ProjectManagerWindow.getInstance(), 
                                         "Would you like to upload changes?", "Upload Changes",
-                                        JOptionPane.YES_NO_OPTION,
+                                        JOptionPane.YES_NO_OPTION, 
                                         JOptionPane.QUESTION_MESSAGE,
                                         null, //do not use a custom Icon
                                         options, //the titles of buttons
                                         options[0]); //default button title
 
                                 switch (selectedOption) {
-                                    case 0:
+                                    case 0:            
                                         // if Commit, upload changes and return to editing
                                         uploadChanges();  // upload changes to database
-                                        makeTableEditable(false); // exit edit mode;
                                         break;
                                     case 1:
                                         // if Revert, revert changes
-                                        loadTable(table); // reverts the model back
-                                        makeTableEditable(false); // exit edit mode;
-
+                                        revertChanges(); // reverts the model back
                                         break;
                                     default:
                                         // do nothing -> cancel
                                         break;
-                                }
+                                }   
 
-                                // highligh previously selected rowIndex
-                                if (rowIndex != -1) {
+                                // highlight previously selected rowIndex
+                                if (rowIndex != -1) 
                                     table.setRowSelectionInterval(rowIndex, rowIndex);
-                                }
                             }
-
-                            // if enter is pressed then enable upload changes button
-                            btnUploadChanges.setEnabled(true);
                         }
-
+                        
                     }
+            
                 }
+                
                 if (!addRecordWindowShow) {
                     if (e.getKeyCode() == KeyEvent.VK_TAB
                             || e.getKeyCode() == KeyEvent.VK_LEFT

--- a/src/com/elle/ProjectManager/presentation/ProjectManagerWindow.java
+++ b/src/com/elle/ProjectManager/presentation/ProjectManagerWindow.java
@@ -1306,8 +1306,8 @@ public class ProjectManagerWindow extends JFrame implements ITableConstants {
         // set the color of the edit mode text
         editModeTextColor(!editing);
 
+        // cell pop up window
         boolean editable = labelEditModeState.getText().equals("ON");
-
         tableCellPopupWindow.enableEdit(editable);
 
     }//GEN-LAST:event_btnSwitchEditModeActionPerformed
@@ -1323,25 +1323,27 @@ public class ProjectManagerWindow extends JFrame implements ITableConstants {
         Tab tab = tabs.get(tabName);
         boolean isAddRecordsBtnVisible = tab.isAddRecordsBtnVisible();
         boolean isBatchEditBtnVisible = tab.isBatchEditBtnVisible();
-
+        
         if (makeTableEditable) {
             labelEditModeState.setText("ON ");
-            btnSwitchEditMode.setVisible(false);
+            btnSwitchEditMode.setVisible(true);
             btnUploadChanges.setVisible(true);
             btnAddRecords.setVisible(false);
-            btnBatchEdit.setVisible(false);
+            btnBatchEdit.setVisible(true);
+            btnRevertChanges.setVisible(true);
         } else {
             labelEditModeState.setText("OFF");
             btnSwitchEditMode.setVisible(true);
             btnUploadChanges.setVisible(false);
             btnAddRecords.setVisible(isAddRecordsBtnVisible);
             btnBatchEdit.setVisible(isBatchEditBtnVisible);
+            btnRevertChanges.setVisible(false);
         }
-
-        for (Map.Entry<String, Tab> entry : tabs.entrySet()) {
+        
+        for (Map.Entry<String, Tab> entry : tabs.entrySet()){
             tab = tabs.get(entry.getKey());
             JTable table = tab.getTable();
-            EditableTableModel model = ((EditableTableModel) table.getModel());
+            EditableTableModel model = ((EditableTableModel)table.getModel());
             model.setCellEditable(makeTableEditable);
         }
     }

--- a/src/com/elle/ProjectManager/presentation/ProjectManagerWindow.java
+++ b/src/com/elle/ProjectManager/presentation/ProjectManagerWindow.java
@@ -1436,9 +1436,26 @@ public class ProjectManagerWindow extends JFrame implements ITableConstants {
     }
 
     private void btnBatchEditActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_btnBatchEditActionPerformed
+        
+        // get selected tab
+        String tabName = getSelectedTabName();
+        Tab tab = tabs.get(tabName);
+        
+        // set the tab to editing
+        tab.setEditing(true);
+        makeTableEditable(true);
+        
+        // set the color of the edit mode text
+        editModeTextColor(tab.isEditing());
+        
+        // open a batch edit window and make visible only to this tab
         batchEditWindow = new BatchEditWindow();
         batchEditWindow.setVisible(true);
-        jPanelEdit.setVisible(false);
+        tab.setBatchEditWindowVisible(true);
+        tab.setBatchEditWindowOpen(true);
+        tab.setBatchEditBtnEnabled(false);
+        setBatchEditButtonStates(tab);
+        
     }//GEN-LAST:event_btnBatchEditActionPerformed
 
     private void menuItemManageDBsActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_menuItemManageDBsActionPerformed

--- a/src/com/elle/ProjectManager/presentation/ProjectManagerWindow.java
+++ b/src/com/elle/ProjectManager/presentation/ProjectManagerWindow.java
@@ -1353,29 +1353,82 @@ public class ProjectManagerWindow extends JFrame implements ITableConstants {
      */
     private void changeTabbedPanelState() {
 
+        // get selected tab
         String tabName = getSelectedTabName();
         Tab tab = tabs.get(tabName);
+        
+        // get booleans for the states of the selected tab
         boolean isActivateRecordMenuItemEnabled = tab.isActivateRecordMenuItemEnabled();
         boolean isArchiveRecordMenuItemEnabled = tab.isArchiveRecordMenuItemEnabled();
-        boolean isAddRecordsBtnVisible = tab.isAddRecordsBtnVisible();
-        boolean isBatchEditBtnVisible = tab.isBatchEditBtnVisible();
-
+        boolean isBatchEditBtnEnabled = tab.isBatchEditBtnEnabled();
+        boolean isBatchEditWindowOpen = tab.isBatchEditWindowOpen();
+        boolean isBatchEditWindowVisible = tab.isBatchEditWindowVisible();
+        
         // this enables or disables the menu components for this tabName
-        menuItemActivateRecord.setEnabled(isActivateRecordMenuItemEnabled);
-        menuItemArchiveRecord.setEnabled(isArchiveRecordMenuItemEnabled);
-
-        // show or hide the add records button and the batch edit button
-        btnAddRecords.setVisible(isAddRecordsBtnVisible);
-        btnBatchEdit.setVisible(isBatchEditBtnVisible);
-
+        menuItemActivateRecord.setEnabled(isActivateRecordMenuItemEnabled); 
+        menuItemArchiveRecord.setEnabled(isArchiveRecordMenuItemEnabled); 
+        
+        // batch edit button enabled is only allowed for table that is editing
+        btnBatchEdit.setEnabled(isBatchEditBtnEnabled);
+        if(isBatchEditWindowOpen){
+            batchEditWindow.setVisible(isBatchEditWindowVisible);
+        }
+        
+        // check whether editing and display accordingly
+        boolean editing = tab.isEditing(); 
+        
+        // must be instance of EditableTableModel 
+        // this method is called from init componenents before the table model is set
+        JTable table = tab.getTable();
+        if(table.getModel() instanceof EditableTableModel){
+            makeTableEditable(editing);
+        }
+        
+        // set the color of the edit mode text
+        editModeTextColor(tab.isEditing());
+        
         // set label record information
         String recordsLabel = tab.getRecordsLabel();
-        labelRecords.setText(recordsLabel);
-
-        // hide buttons if in edit mode
-        if (labelEditModeState.getText().equals("ON ")) {
+        labelRecords.setText(recordsLabel);    
+        
+        // buttons if in edit mode
+        if(labelEditModeState.getText().equals("ON ")){
             btnAddRecords.setVisible(false);
-            btnBatchEdit.setVisible(false);
+            btnBatchEdit.setVisible(true);
+        }
+        
+        // batch edit window visible only on the editing tab
+        if(batchEditWindow != null){
+            boolean batchWindowVisible = tab.isBatchEditWindowVisible();
+            batchEditWindow.setVisible(batchWindowVisible);
+        }
+        
+        // if this tab is editing
+        if(editing){
+            
+            // if there is no modified data
+            if(tab.getTableData().getNewData().isEmpty()){
+                setEnabledEditingButtons(true, false, false);
+            }
+                
+            // there is modified data to upload or revert
+            else{
+                setEnabledEditingButtons(false, true, true);
+            }
+        }
+        
+        // else if no tab is editing
+        else if(!isTabEditing()){
+            btnSwitchEditMode.setEnabled(true);
+            btnAddRecords.setEnabled(true);
+            btnBatchEdit.setEnabled(true);
+        }
+        
+        // else if there is a tab editing but it is not this one
+        else if(isTabEditing()){
+            btnSwitchEditMode.setEnabled(false);
+            btnAddRecords.setEnabled(false);
+            btnBatchEdit.setEnabled(false);
         }
     }
 


### PR DESCRIPTION
  ProjectManager-0.9.0 *** NEW JAR ***
   - button enabled behavior determined by editing states
   - edit mode text is now green when editing mode is on

- update all features from Analyster to ProjectManager
  - see notes from Wednesday 23 Sept. -> Thursday 1 Oct. for all the detailed notes on the features implemented

check list 
 - removed the panel for batch edit buttons
 - added color variables for the edit mode text
 - initialize colors and change naming conventions
 - hide button revert changes and refactor the name
 - implemented switch button code and required methods that were added, as well as update the tab class
 - double right mouse click enter edit mode code implemented
   - notes- I noticed the code for the left mouse double click and single click which I hope does not break functionality (I have not tested)
   - update: the code appears to work fine when I tested. The double click filter feature works as long as no text pop up is associated with that cell.
 - changeTabbedPaneState method code implemented 
 - upload changes code implemented
 - revert changes code implemented
 - batch edit button code implemented
 - initialize all tabs as not in an editing mode active state
 - makeTableEditable code updated
 - setKeyboardFocusManager code updated
 - batch edit quit button code implemented
 - tableModelListener code updated
 - single left mouse click feature code updated
   - this just selects the cell ( you can start typing or use double right click to enter cell and select all text)
 - removed line of code from LoginWindow - set window not visible when object is created
  - I usually set visible when I create an object. That is the way that the java api seems to do it.
    - example create a new JFrame and you won't see it until you put setVisible to true because it should be false by default.